### PR TITLE
asg: provide lifecycle ignore changes fields.

### DIFF
--- a/autoscaling_with_launch_template/autoscaling_group.tf
+++ b/autoscaling_with_launch_template/autoscaling_group.tf
@@ -79,7 +79,7 @@ resource "aws_autoscaling_group" "default" {
 
   lifecycle {
     create_before_destroy = true
-    ignore_changes        = [desired_capacity]
+    ignore_changes        = [desired_capacity, name, target_group_arns]
   }
 
   tags = local.asg_tags

--- a/autoscaling_with_launch_template/launch_template.tf
+++ b/autoscaling_with_launch_template/launch_template.tf
@@ -55,6 +55,10 @@ resource "aws_launch_template" "default" {
     )
   }
 
+  lifecycle {
+    ignore_changes = [name]
+  }
+
   tags = merge(local.default_tags)
 }
 

--- a/autoscaling_with_launch_template/security_groups.tf
+++ b/autoscaling_with_launch_template/security_groups.tf
@@ -18,6 +18,7 @@ resource "aws_security_group" "instances" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [name_prefix]
   }
 }
 

--- a/eks_nodegroup/main.tf
+++ b/eks_nodegroup/main.tf
@@ -3,12 +3,20 @@ resource "random_id" "iam_instance_profile_id" {
     name = local.resource_identifier
   }
 
+  lifecycle {
+    ignore_changes = [keepers]
+  }
+
   byte_length = 4
 }
 
 resource "aws_iam_instance_profile" "default" {
   name = "${local.resource_identifier}-${random_id.iam_instance_profile_id.hex}-instance-role"
   role = data.aws_iam_role.default.name
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 module "nodegroup" {

--- a/eks_nodegroup/variables.tf
+++ b/eks_nodegroup/variables.tf
@@ -121,7 +121,7 @@ variable "spot_allocation_strategy" {
 }
 
 variable "spot_instance_pools" {
-  default = 0
+  default = 3
 }
 
 variable "fab_tag" {


### PR DESCRIPTION
This change is made due to the following reasons:
1. We do not want to replce an ASG (or any reasource) when its name has changed.
   When we really want the name to change, we can write a new terraform
   and destroy the old resources. This is required in k8s especially, where
   we need to change ASG properties without replacing the entire ASG,
   when these properties are responsible for generating the ASG name.

2. We want to manage target groups attachements to ASG seperately,outside of terraform.
   For static target groups attachments, there would be no/rare changes to this field.
   For dynamic target groups, we still can maintain the attachment without terraform.