### PR TITLE
set device_index for autoscaling_with_launch_template/launch_template.tf

### DIFF
--- a/autoscaling_with_launch_template/launch_template.tf
+++ b/autoscaling_with_launch_template/launch_template.tf
@@ -27,6 +27,7 @@ resource "aws_launch_template" "default" {
   }
 
   network_interfaces {
+    device_index = 0
     associate_public_ip_address = var.associate_public_ip_address
     security_groups = concat(
       [aws_security_group.instances.id],


### PR DESCRIPTION
To resolve 
```
Error: Error creating Auto Scaling Group: InvalidQueryParameter: Incompatible launch template: Each network interface requires a unique device index.
